### PR TITLE
Updated pressure calculations for calc_clean.py

### DIFF
--- a/test_platform/scripts/2_clean_data/calc_clean.py
+++ b/test_platform/scripts/2_clean_data/calc_clean.py
@@ -126,7 +126,7 @@ def _lat_dms_to_dd(data):
     data = float(data[:2]) + float(data[2:4])/60 + float(data[5:])/3600
     return data
 
-def _lon_dms_to_dd(data): ## THIS IS NOT WORKING
+def _lon_dms_to_dd(data): 
     """
     Converts longitude from decimal-minutes-seconds to decimal degrees
     and ensures that western hemisphere lons are negative by convention
@@ -248,4 +248,5 @@ def _calc_ps_alt(alt, elev):
     """
     alt = alt / 3386.39 # Convert altimeter from Pa to inHg for use in formula
     ps = alt * ((288-0.0065*elev)/288)**5.2561
+    ps = _unit_pres_inHg_to_pa(ps) # Convert back to Pa from inHg
     return ps


### PR DESCRIPTION
Should be a quick PR: 
- Updated _calc_ps() function call with validated formula
- New _calc_ps_alt() function which calculates station air pressure from an altimeter setting and elevation if station pressure is not available. 

All outputs should be in Pascals.

EDITED TO ADD: Sorry, forgot about the two additional conversions I had in there for CWOP-solar rad:
- _lat_DMm_to_Dd() and _lon_DMm_to_Dd() are also in there because CWOP apparently uses LORAN coordinates for most, but not all observations... 