### PR TITLE
Missing data flags for cleaning stage, mainly for easy read in

### DIFF
--- a/test_platform/scripts/2_clean_data/missing_data_flags.csv
+++ b/test_platform/scripts/2_clean_data/missing_data_flags.csv
@@ -16,8 +16,6 @@ NULL,MADIS,,https://developers.synopticdata.com/about/qc/
 ….,CWOP,may get replaced by space character by MADIS qa,
 6////,ASOSAWOS,,https://www.weather.gov/media/asos/aum-toc.pdf
 7////,ASOSAWOS,,https://www.weather.gov/media/asos/aum-toc.pdf
-M,CDEC,,https://wrcc.dri.edu/cgi-bin/wea_listex.pl?flags
-M,CIMIS,missing,
 999999,MADIS,,https://madis-data.ncep.noaa.gov/raobdump.f
 MM,MARITIME,realtime data (less than 45 days old),https://www.ndbc.noaa.gov/measdes.shtml
 9999.0,MARITIME,historical data,https://www.ndbc.noaa.gov/measdes.shtml
@@ -29,4 +27,3 @@ MM,NDBC,realtime data (less than 45 days old),https://www.ndbc.noaa.gov/measdes.
 99.0,NDBC,historical data,https://www.ndbc.noaa.gov/measdes.shtml
 -9999,NOS-NWLON,,https://tidesandcurrents.noaa.gov/publications/tech_rpt_026.pdf
 -9999,NOS-PORTS,,https://tidesandcurrents.noaa.gov/publications/tech_rpt_026.pdf
-M,RAWS,,https://wrcc.dri.edu/cgi-bin/wea_listex.pl?flags


### PR DESCRIPTION
Adds a simple csv file of the relevant missing data flags I could find sources for. I also did the barest look through of each network to ensure I wasn't missing anything painfully obvious. 

The big ones that will be appropriate for us will be a space character (MADIS), or some variation on repeating "9"s with or without a "+" character in front of it, e.g., +9999999. Will point out that MARITIME/NDBC appears to have repeating 9s **with a decimal point 0**, e.g., "999.0"

At present, there are duplicates, and it's unsorted. Happy to remove duplicates and clean up notes/network/source as requested! Also happy to add other common flags such as 1e+34 etc.