### PR TITLE
fix spacing issue in CAHYDRO name

### DIFF
--- a/test_platform/scripts/1_pull_data/MADIS_sensors.py
+++ b/test_platform/scripts/1_pull_data/MADIS_sensors.py
@@ -1,3 +1,10 @@
+"""
+This script outputs a sensor list csv for each of the MADIS networks and is saved to the
+qaqc_wx folder for each network.
+
+This script only needs to be run occasionally/when a full MADIS pull occurs.
+"""
+
 # Step 0: Environment set-up
 import requests
 import pandas as pd
@@ -27,7 +34,7 @@ wecc_mar = "s3://wecc-historical-wx/0_maps/WECC_Informational_MarineCoastal_Boun
 directory = "3_qaqc_wx/"
 
 # List of MADIS network names
-madis_networks = ['CAHYDRO', 'CDEC', 'CNRFC', 'CRN', 'CWOP', 'HNXWFO', 'HOLFUY', 'HPWREN', 'LOXWFO', 'MAP', 'MTRWFO', 'NCAWOS', 'NOS-NWLON', 'NOS-PORTS',
+madis_networks = ['CA HYDRO', 'CDEC', 'CNRFC', 'CRN', 'CWOP', 'HNXWFO', 'HOLFUY', 'HPWREN', 'LOXWFO', 'MAP', 'MTRWFO', 'NCAWOS', 'NOS-NWLON', 'NOS-PORTS',
 'RAWS', 'SGXWFO', 'SHASAVAL', 'VCAPCD']
 
 # Get dictionary of network names and short IDs
@@ -40,6 +47,7 @@ def madis_network_name_to_id(token, networks):
     networks = networks[networks['SHORTNAME'].isin(shortnames)]
     networks = networks[['SHORTNAME', 'ID']]
     networks['SHORTNAME'] = networks['SHORTNAME'].replace(to_replace="APRSWXNET/CWOP", value = "CWOP")
+    networks['SHORTNAME'] = networks['SHORTNAME'].replace(to_replace="CA HYDRO", value="CAHYDRO") # removes space issue
     return networks
 
 
@@ -52,17 +60,17 @@ def get_madis_sensor_metadata(token, terrpath, marpath, networks, bucket_name, d
         for index, row in networks.iterrows():
             networkname = row['SHORTNAME']
             networkid = row['ID']
-            
+
             # Access station metadata to get list of IDs in bbox and network
             # Using: https://developers.synopticdata.com/mesonet/v2/stations/timeseries/
             url = "https://api.synopticdata.com/v2/stations/metadata?token={}&network={}&bbox={}&complete=1&sensorvars=1&recent=20&output=json".format(token, networkid, bbox_api)
             request = requests.get(url).json()
-            
+
             ids = []
             station_list = pd.DataFrame(request['STATION'])
             station_list = pd.concat([station_list, station_list["PERIOD_OF_RECORD"].apply(pd.Series)], axis=1) # Split Period of Record column
             station_list = pd.concat([station_list, station_list["UNITS"].apply(pd.Series)], axis=1) # Split Period of Record column
-            station_list = pd.concat([station_list, station_list["SENSOR_VARIABLES"].apply(pd.Series)], axis=1) # Split Variables column
+            station_list = pd.concat([station_list, station_list["SENSOR_VARIABLES"].apply(pd.Series, dtype='string')], axis=1) # Split Variables column
             station_list = station_list.drop("PERIOD_OF_RECORD", axis =1)
             station_list = station_list.drop("UNITS", axis =1)
             station_list = station_list.drop("SENSOR_VARIABLES", axis =1)
@@ -75,10 +83,10 @@ def get_madis_sensor_metadata(token, terrpath, marpath, networks, bucket_name, d
 
             # Get index of 'end', last standard column
             end_ind = station_list.columns.get_loc("end")
-            
+
             # Drop columns
             station_list = station_list.drop(columns=[col for col in station_list.columns[end_ind+1:] if col not in coltokeep]) # Drop all columns not in coltokeep list.
-        
+
             # Each sensor has a column of dictionaries. For each sensor, collapse column.
             cols_in_df = [i for i in coltokeep if i in station_list.columns]
             for i in cols_in_df:
@@ -96,13 +104,14 @@ def get_madis_sensor_metadata(token, terrpath, marpath, networks, bucket_name, d
 
             # Save station list to AWS
             savedir = directory+networkname+"/"
-            
+
             csv_buffer_err = StringIO()
             station_list.to_csv(csv_buffer_err)
             content = csv_buffer_err.getvalue()
-            
+
+            print("Sensor list saved for {}.".format(networkname))
             s3_cl.put_object(Bucket=bucket_name, Body=content, Key=savedir+"sensorlist_{}.csv".format(networkname))
-        
+
     except Exception as e:
         print("Error: {}".format(e))
 

--- a/test_platform/scripts/2_clean_data/MADIS_clean.py
+++ b/test_platform/scripts/2_clean_data/MADIS_clean.py
@@ -72,7 +72,7 @@ def get_file_paths(network):
     cleandir = "2_clean_wx/{}/".format(network)
     qaqcdir = "3_qaqc_wx/{}/".format(network)
     return rawdir, cleandir, qaqcdir
-              
+
 
 ## FUNCTION: Get MADIS QA/QC flag data and parse into csv.
 # Input: API url for QAQC metadata.
@@ -86,11 +86,11 @@ def get_qaqc_flags(token, bucket_name, qaqcdir, network):
     for each in request['QCTYPES']:
         ids.append([each['ID'], each['SHORTNAME'], each['NAME']])
     ids = pd.DataFrame(ids, columns = ['FLAG', 'SHORTNAME', 'NAME']) # Sort by start date (note some stations return 'None' here)
-    
+
     # Save to AWS bucket.
     #print(ids)
     print("Saving QAQC flags to csv file.")
-    
+
     csv_buffer = StringIO()
     ids.to_csv(csv_buffer, index = False)
     content = csv_buffer.getvalue()
@@ -98,7 +98,7 @@ def get_qaqc_flags(token, bucket_name, qaqcdir, network):
     return ids
 
 ## FUNCTION: Clean MADIS data.
-# Input: 
+# Input:
 # bucket_name: name of AWS bucket.
 # rawdir: path to where raw data is saved as .csv files, with each file representing a station's records from download start date to present (by default 01-01-1980).
 # Some stations have more than one csv file, with the second file named 2_[STID].csv, and so on.
@@ -118,8 +118,8 @@ def parse_madis_headers(file):
         if index>10:
             return
         index += 1
-        row = (line.decode('utf-8')) 
-        
+        row = (line.decode('utf-8'))
+
         if "STATION:" in row: # Skip first row.
             station_id = row.partition(": ")[2].replace(" ", "").replace("\n", "")
             #print(station_id) # For testing
@@ -140,7 +140,7 @@ def parse_madis_headers(file):
         elif "STATE" in row:
             state = row.partition(": ")[2].replace("']", "").replace("\n", "")
             continue
-        
+
         elif "Station_ID" in row:
             columns = row
             columns = columns.split(",")
@@ -152,18 +152,18 @@ def parse_madis_headers(file):
             units = units.replace("\n", "")
             continue
 
-        else:    
+        else:
             # Get row where data begins (station ID first appears)
             if station_id in row:
                 first_row = index
                 break
             else:
                 continue
-                
+
     # Read in entire csv starting at first_row, using pandas.
     # First, some error handling.
-    
-    #Check for duplicated columns. If duplicated names, manually rename as 1 and 2, and then check for duplicates after reading in.    
+
+    #Check for duplicated columns. If duplicated names, manually rename as 1 and 2, and then check for duplicates after reading in.
     if set([x for x in columns if columns.count(x) > 1]):
         dup = True # Add dup flag.
         dup_col = set([x for x in columns if columns.count(x) > 1])
@@ -173,12 +173,12 @@ def parse_madis_headers(file):
     else:
         dup = False
         dup_col = []
-    
-    headers = {'station_id':station_id, 'station_name':station_name, 'latitude':latitude, 'longitude':longitude, 'elevation':elevation, 'state':state, 'columns':columns, 
+
+    headers = {'station_id':station_id, 'station_name':station_name, 'latitude':latitude, 'longitude':longitude, 'elevation':elevation, 'state':state, 'columns':columns,
                 'units': units, 'first_row': first_row, 'dup': dup, 'dup_col': dup_col}
-    
+
     #print(headers) # For testing.
-    
+
     return headers
 
 # Function: take heads, read csv into pandas db and clean.
@@ -210,9 +210,9 @@ def parse_madis_to_pandas(file, headers, errors, removedvars):
     # Fix time format issues caused by "Timeout" errors.
     df['Date_Time'] = pd.to_datetime(df['Date_Time'], errors = 'coerce') # Convert time to datetime and catch any incorrectly formatted columns.
     df = df[pd.notnull(df['Date_Time'])] # Remove any rows where time is missing.
-    
+
     df = df.loc[(df['Date_Time']<'09-01-2022') & (df['Date_Time']>'12-31-1979')]# TIME FILTER: Remove any rows before Jan 01 1980 and after August 30 2022.
-    
+
     # Remove any non-essential columns.
     coltokeep = ['Station_ID', 'Date_Time', 'altimeter_set_1', 'altimeter_set_1_qc',
                 'air_temp_set_1', 'air_temp_set_1_qc', 'relative_humidity_set_1',
@@ -221,42 +221,42 @@ def parse_madis_to_pandas(file, headers, errors, removedvars):
                 'precip_accum_since_local_midnight_set_1_qc',
                 'precip_accum_24_hour_set_1', 'precip_accum_24_hour_set_1_qc',
                 'dew_point_temperature_set_1d', 'pressure_set_1d',
-                'pressure_set_1', 'pressure_set_1_qc', 'dew_point_temperature_set_1', 'dew_point_temperature_set_1_qc', 
-                'precip_accum_one_hour_set_1', 'precip_accum_one_hour_set_1_qc', 'solar_radiation_set_1', 'solar_radiation_set_1_qc', 
+                'pressure_set_1', 'pressure_set_1_qc', 'dew_point_temperature_set_1', 'dew_point_temperature_set_1_qc',
+                'precip_accum_one_hour_set_1', 'precip_accum_one_hour_set_1_qc', 'solar_radiation_set_1', 'solar_radiation_set_1_qc',
                 'precip_accum_set_1', 'precip_accum_set_1_qc', 'precip_accum_five_minute_set_1', 'precip_accum_five_minute_set_1_qc']
-    
-    othercols = [col for col in df.columns if col not in coltokeep and col not in removedvars] 
+
+    othercols = [col for col in df.columns if col not in coltokeep and col not in removedvars]
     #print(removedvars)
     #print(othercols)
 
     removedvars += othercols # Add any new columns from drop list to removedvars, to save later.
     df = df.drop(columns=[col for col in df if col not in coltokeep]) # Drop all columns not in coltokeep list.
-    
+
     # # Manually convert "None" to np.nan
     df.replace(to_replace="None", value=np.nan, inplace=True)
 
     # Remove "status" error rows
-    df = df.loc[df["Station_ID"].str.contains("status")==False]  
-    
+    df = df.loc[df["Station_ID"].str.contains("status")==False]
+
     return df
 
 def clean_madis(bucket_name, rawdir, cleandir, network):
     try:
         files = []
-        for item in s3.Bucket(bucket_name).objects.filter(Prefix = rawdir): 
+        for item in s3.Bucket(bucket_name).objects.filter(Prefix = rawdir):
             file = str(item.key)
             files += [file]
 
         files = list(filter(lambda f: f.endswith(".csv"), files)) # Get list of file names
         files = [file for file in files if "error" not in file] # Remove error handling files.
         files = [file for file in files if "station" not in file] # Remove error handling files.
-        
+
         # Set up error handling.
         errors = {'File':[], 'Time':[], 'Error':[]} # Set up error handling.
         end_api = datetime.now().strftime('%Y%m%d%H%M') # Set end time to be current time at beginning of download: for error handling csv.
         timestamp = datetime.utcnow().strftime("%m-%d-%Y, %H:%M:%S") # For attributes of netCDF file.
 
-            
+
         # Set up list of variables to be removed
         removedvars = []
 
@@ -272,21 +272,17 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
         # Get sensor metadata from QA/QC folder
         sensor_filepath = "s3://wecc-historical-wx/3_qaqc_wx/{}/sensorlist_{}.csv".format(network, network)
         sensor_data = pd.read_csv(smart_open.smart_open(sensor_filepath))
-        
+
     except Exception as e: # If unable to read files from cleandir, break function.
         errors['File'].append("Whole network")
         errors['Time'].append(end_api)
         errors['Error'].append(e)
-    
+
     else: # If files read successfully, continue.
 
-        ids.append("junk") # For testing errors
-
         #for i in ids: # For each station (full run)
-        #for i in ids[0:5]: # Subsample for testing merge
-        #for i in ids[-20:]: # Subsample for testing errors    
-        for i in sample(ids, 10):
-        #for i in ["CEZC2"]:
+        for i in sample(ids, 5):
+
             try:
                 stat_files = [k for k in files if i in k] # Get list of files with station ID in them.
                 station_id = "{}_".format(network)+i.upper() # Save file ID as uppercase always.
@@ -304,7 +300,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                             errors['Error'].append("No data available for station. Cleaning stage skipped.")
                             stat_files.remove(file) # Remove from file list
                             continue
-                        headers.append(header)  
+                        headers.append(header)
                     except Exception as e:
                         errors['File'].append(file)
                         errors['Time'].append(end_api)
@@ -313,7 +309,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
 
                 if not stat_files: # If no files left in list
                     continue
-            
+
                 # If more than one station, metadata should be identical. Test this.
                 if(all(a == headers[0] for a in headers[1:])):
                     headers = headers[0]
@@ -338,13 +334,13 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     errors['File'].append(stat_files)
                     errors['Time'].append(end_api)
                     errors['Error'].append(e)
-            
+
             except Exception as e:
                 errors['File'].append(i) # If stat_files is none, this will default to saving ID of station.
                 errors['Time'].append(end_api)
                 errors['Error'].append(e)
                 continue
-            
+
             try:
                 station_name = headers['station_name'] # Get station name
                 file_count = len(dfs)
@@ -359,7 +355,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 if 'Fahrenheit' in units['units']: # Pull code set to get units as metric. Break if this condition is not met.
                     print("Units not standardized! Fix code")
                     exit()
-                
+
                 # Fix multi-type columns
                 # If column has QC in it, force to string.
                 for b in df_stat.columns:
@@ -393,10 +389,10 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 # Sort by time and remove any overlapping timestamps.
                 df_stat = df_stat.sort_values(by = "Date_Time")
                 df_stat = df_stat.drop_duplicates()
-                
+
                 # Move df to xarray object.
                 ds = df_stat.to_xarray()
-                
+
                 # Update global attributes
                 ds = ds.assign_attrs(title = "{} cleaned".format(network))
                 ds = ds.assign_attrs(institution = "Eagle Rock Analytics / Cal Adapt")
@@ -418,12 +414,12 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 ds = ds.expand_dims("id") # Add station_id as index.
                 ds = ds.drop_vars(("index")) # Drop station_id variable and index coordinate.
                 ds = ds.rename({'id': 'station'}) # Rename id to station_id.
-                
-                    
+
+
                 # Add coordinates: latitude and longitude.
                 lat = np.asarray([headers['latitude']]*len(ds['time']))
                 lat.shape = (1, len(ds['time']))
-                
+
                 lon = np.asarray([headers['longitude']]*len(ds['time']))
                 lon.shape = (1, len(ds['time']))
 
@@ -434,41 +430,41 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 if np.count_nonzero(np.isnan(ds['lat'])) != 0:
                     #print("Dropping missing lat values") # For testing.
                     ds = ds.where(~np.isnan(ds['lat']))
-                
+
                 if np.count_nonzero(np.isnan(ds['lon'])) != 0:
                     #print("Dropping missing lon values") # For testing.
                     ds = ds.where(~np.isnan(ds['lon']))
-                
+
                 # Add variable: elevation
                 elev = np.asarray([headers['elevation']]*len(ds['time']))
                 elev.shape = (1, len(ds['time']))
                 ds['elevation'] = (['station', 'time'], elev)
-                
+
                 # Update dimension and coordinate attributes.
-            
+
                 # Convert column to datetime (and remove any rows that cannot be coerced).
                 ds['time'] = pd.to_datetime(ds['time'], utc = True) # Convert from string to incorrect time format.
                 ds['time'] = pd.to_datetime(ds['time'], unit = 'ns') # Fix time format.
-                
+
                 # Update attributes.
                 ds['time'].attrs['long_name'] = "time"
                 ds['time'].attrs['standard_name'] = "time"
                 ds['time'].attrs['comment'] = "In UTC."
-                
+
                 # Station ID
                 ds['station'].attrs['long_name'] = "station_id"
                 ds['station'].attrs['comment'] = "Unique ID created by Eagle Rock Analytics. Includes network name appended to original unique station ID provided by network."
-                
+
                 # Latitude
                 ds['lat'].attrs['long_name'] = "latitude"
                 ds['lat'].attrs['standard_name'] = "latitude"
                 ds['lat'].attrs['units'] = "degrees_north"
-                
+
                 # Longitude
                 ds['lon'].attrs['long_name'] = "longitude"
                 ds['lon'].attrs['standard_name'] = "longitude"
                 ds['lon'].attrs['units'] = "degrees_east"
-                
+
                 # Elevation
                 # Convert from feet to meters.
                 ds['elevation'] = calc_clean._unit_elev_ft_to_m(ds['elevation']) # Convert feet to meters.
@@ -478,7 +474,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 ds['elevation'].attrs['units'] = "meters"
                 ds['elevation'].attrs['positive'] = "up" # Define which direction is positive
                 ds['elevation'].attrs['comment'] = "Converted from feet to meters."
-                
+
 
                 # Update sensor metadata
                 station_sensors = sensor_data.loc[sensor_data.STID==i] # May be multiple rows if sensors added/removed over time.
@@ -495,11 +491,11 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
 
                     # Wind speed & direction (m)
                     if 'wind_speed_1_position' in sensorheights.columns and True in sensorheights.wind_speed_1_position.notnull().values: # If any value not null
-                        if len(sensorheights.wind_speed_1_position)>1 and sensorheights.wind_speed_1_position.nunique() != 1: 
+                        if len(sensorheights.wind_speed_1_position)>1 and sensorheights.wind_speed_1_position.nunique() != 1:
                             print(f"{station_id} has more than one wind sensor height. Check these are saved as expected.") # Testing, to flag cases of this.
                             # If more than one anemometer sensor w/ diff heights
                             # Use time column to name attributes
-                            
+
                             # Get start date for each sensor height
                             start_dates = station_sensors.sort_values('wind_speed_1_start').groupby('wind_speed_1_position').head(1)
                             start_dates = start_dates[['wind_speed_1_position', 'wind_speed_1_start']]
@@ -522,15 +518,15 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                             ds = ds.assign_attrs(anemometer_height_m = float(sensor_height[0]))
                     else:
                         ds = ds.assign_attrs(anemometer_height_m = np.nan)
-                    
-                        
+
+
                     # Air temperature (m)
                     if 'air_temp_1_position' in sensorheights.columns and True in sensorheights.air_temp_1_position.notnull().values: # If any value not null
-                        if len(sensorheights.air_temp_1_position)>1 and sensorheights.air_temp_1_position.nunique() != 1: 
+                        if len(sensorheights.air_temp_1_position)>1 and sensorheights.air_temp_1_position.nunique() != 1:
                             print(f"{station_id} has more than one air temp sensor height. Check these are saved as expected.") # Testing, to flag cases of this.
                             # If more than one anemometer sensor w/ diff heights
                             # Use time column to name attributes
-                            
+
                             # Get start date for each sensor height
                             start_dates = station_sensors.sort_values('air_temp_1_start').groupby('air_temp_1_position').head(1)
                             start_dates = start_dates[['air_temp_1_position', 'air_temp_1_start']]
@@ -547,21 +543,21 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                             for index, row in dates.iterrows():
                                 row['names'] = f'thermometer_height_m_{row.air_temp_1_start[0:10]}_{row.air_temp_1_end[0:10]}'
                                 ds.attrs[row['names']] = float(row['air_temp_1_position'])
-                        else:        
+                        else:
                             sensor_height = sensorheights.air_temp_1_position.dropna().unique() # Get all unique values from column.
-                            ds = ds.assign_attrs(thermometer_height_m = float(sensor_height[0]))   
+                            ds = ds.assign_attrs(thermometer_height_m = float(sensor_height[0]))
                     else:
                         ds = ds.assign_attrs(thermometer_height_m = np.nan)
-                    
-                        
+
+
                     # Barometer elevation (convert from height)
                     if 'pressure_1_position' in sensorheights.columns and True in sensorheights.pressure_1_position.notnull().values: # If any value not null
-                        
-                        if len(sensorheights.pressure_1_position)>1 and sensorheights.pressure_1_position.nunique() != 1: 
+
+                        if len(sensorheights.pressure_1_position)>1 and sensorheights.pressure_1_position.nunique() != 1:
                             print(f"{station_id} has more than one pressure sensor height. Check these are saved as expected.") # Testing, to flag cases of this.
                             # If more than one anemometer sensor w/ diff heights
                             # Use time column to name attributes
-                            
+
                             # Get start date for each sensor height
                             start_dates = station_sensors.sort_values('pressure_1_start').groupby('pressure_1_position').head(1)
                             start_dates = start_dates[['pressure_1_position', 'pressure_1_start']]
@@ -584,7 +580,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                                     row['names'] = f'barometer_height_m_{row.pressure_1_start[0:10]}_{row.pressure_1_end[0:10]}'
                                     ds.attrs[row['names']] = float(row['pressure_1_position'])
                                     ds = ds.assign_attrs(barometer_elevation_m = np.nan)
-                            
+
                         else:
                             if pd.notnull(ds['elevation'].values[0]): # If station has elevation
                                 sensor_height = sensorheights.pressure_1_position.dropna().unique() # Get all unique values from column.
@@ -594,14 +590,14 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                                 sensor_height = sensorheights.pressure_1_position.dropna().unique() # Get all unique values from column.
                                 ds = ds.assign_attrs(barometer_height_m = sensor_height[0])
                                 ds = ds.assign_attrs(barometer_elevation_m = np.nan)
-                        
-                                
+
+
                     else:
                         ds = ds.assign_attrs(barometer_elevation_m = np.nan)
 
                     # Any other sensors with values
                     sensorheights = sensorheights.dropna(axis="columns", how="all") # Drop all-na columns
-                    
+
                     # For precip columns, get single value
                     precip_heights = sensorheights[[col for col in sensorheights.columns if 'precip' in col]]
                     if not precip_heights.isnull().values.all(): # if any value not NaN
@@ -613,13 +609,13 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                                 exit() # To do!
                         else:
                             ds = ds.assign_attrs(rain_gauge_height_m = float(precip_heights.values[0]))
-                    
+
 
                     # Currently, these only take one sensor height if there is more than one provided.
                     for col in sensorheights.columns:
                         if col not in ['altimeter_1_position', 'wind_speed_1_position', 'pressure_1_position']:
 
-                            sensor_height = sensorheights[col].dropna().unique() 
+                            sensor_height = sensorheights[col].dropna().unique()
                             if col == 'relative_humidity_1_position':
                                 ds = ds.assign_attrs(humidity_height_m = float(sensor_height[0]))
                             if col == 'dew_point_temperature_1_position':
@@ -630,20 +626,20 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                                 ds = ds.assign_attrs(wind_vane_height_m = float(sensor_height[0]))
 
                 # Update variable attributes and do unit conversions
-                
+
                 #tas: air surface temperature (K)
                 if "air_temp_set_1" in ds.keys():
                     ds['tas'] = calc_clean._unit_degC_to_K(ds['air_temp_set_1'])
                     ds = ds.drop("air_temp_set_1")
-                    
-                    
+
+
                     if "air_temp_set_1_qc" in ds.keys():
                         # Flag values are listed in this column and separated with ; when more than one is used for a given observation.
                         flagvals = ds['air_temp_set_1_qc'].values.tolist()[0]
                         flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                         flagvals = list(np.unique(flagvals)) # Get unique values
                         flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                        
+
                         if flagvals == ['nan']: # This should not occur, but leave in here for additional robustness.
                             #print("Flag value is {}".format(flagvals)) # For testing.
                             ds = ds.drop("air_temp_set_1_qc")
@@ -651,19 +647,19 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                             ds['tas'].attrs['standard_name'] = "air_temperature"
                             ds['tas'].attrs['units'] = "degree_Kelvin"
                             ds['tas'].attrs['comment'] = "Converted from Celsius to Kelvin."
-                            
+
                         else:
                             ds = ds.rename({'air_temp_set_1_qc': 'tas_qc'})
                             flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                             ds['tas_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                             ds['tas_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                            
+
                             ds['tas'].attrs['long_name'] = "air_temperature"
                             ds['tas'].attrs['standard_name'] = "air_temperature"
                             ds['tas'].attrs['units'] = "degree_Kelvin"
                             ds['tas'].attrs['ancillary_variables'] = "tas_qc" # List other variables associated with variable (QA/QC)
                             ds['tas'].attrs['comment'] = "Converted from Celsius to Kelvin."
-                            
+
                     else:
                         ds['tas'].attrs['long_name'] = "air_temperature"
                         ds['tas'].attrs['standard_name'] = "air_temperature"
@@ -676,11 +672,11 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 # We will manually recalculate this here.
 
                 # Set up column.
-                
+
                 if 'pressure_set_1' in ds.keys(): # If station pressure directly observed
                     if not np.isnan(ds['pressure_set_1'].values).all(): # If station pressure directly observed
                         ds = ds.rename({'pressure_set_1': 'ps'})
-                        
+
                         # Set attributes
                         ds['ps'].attrs['long_name'] = "station_air_pressure"
                         ds['ps'].attrs['standard_name'] = "air_pressure"
@@ -701,7 +697,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                    
+
                     if flagvals == ['nan']: # This should not occur, but leave in here for additional check.
                         #print("Flag value is {}".format(flagvals)) # For testing.
                         ds = ds.drop("pressure_set_1_qc")
@@ -719,7 +715,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                         flagvals = list(np.unique(flagvals)) # Get unique values
                         flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                        
+
                         if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                             ds = ds.drop("sea_level_pressure_set_1_qc")
                         else:
@@ -731,7 +727,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     else: # if no sea level pressure, drop QC flags.
                         ds = ds.drop("sea_level_pressure_set_1_qc")
 
-                            
+
                 # tdps: dew point temperature (K)
                 # if raw dew point temperature observed, use that.
                 if 'dew_point_temperature_set_1' in ds.keys():
@@ -743,7 +739,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     ds['tdps'].attrs['standard_name'] = "dew_point_temperature"
                     ds['tdps'].attrs['units'] = "degree_Kelvin"
                     ds['tdps'].attrs['comment'] = "Converted from Celsius to Kelvin."
-                
+
                     # QAQC flag
                     if "dew_point_temperature_set_1_qc" in ds.keys():
                     # Flag values are listed in this column and separated with ; when more than one is used for a given observation.
@@ -751,7 +747,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                         flagvals = list(np.unique(flagvals)) # Get unique values
                         flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                        
+
                         if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                             #print("Flag value is {}".format(flagvals)) # For testing.
                             ds = ds.drop("dew_point_temperature_set_1_qc")
@@ -760,9 +756,9 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                             flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                             ds['tdps_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                             ds['tdps_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                            
+
                             ds['tdps'].attrs['ancillary_variables'] = "tdps_qc" # List other variables associated with variable (QA/QC)
-                            
+
 
                 # pr: precipitation
                 # We have 4 different raw precipitation variables for precip.
@@ -772,7 +768,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 # precip_accum_one_hour_set_1 # Precipitation in last hour.
 
                 # At this stage, no infilling. So we will keep all columns with data and simply rename them.
-                
+
                 # Reformat remaining columns
                 if "precip_accum_24_hour_set_1" in ds.keys():
                     ds = ds.rename({'precip_accum_24_hour_set_1': 'pr_24h'})
@@ -782,7 +778,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
 
                     if 'precip_accum_24_hour_set_1_qc' in ds.keys():
                         ds = ds.rename({'precip_accum_24_hour_set_1_qc': 'pr_24h_qc'})
-                
+
                 if 'precip_accum_since_local_midnight_set_1' in ds.keys():
                     ds = ds.rename({'precip_accum_since_local_midnight_set_1': 'pr_localmid'})
                     ds['pr_localmid'].attrs['long_name'] = "precipitation_since_local_midnight"
@@ -791,7 +787,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
 
                     if 'precip_accum_since_local_midnight_set_1_qc' in ds.keys():
                         ds = ds.rename({'precip_accum_since_local_midnight_set_1_qc': 'pr_localmid_qc'})
-                
+
                 if "precip_accum_set_1" in ds.keys():
                     ds = ds.rename({'precip_accum_set_1': 'pr'})
                     ds['pr'].attrs['long_name'] = "precipitation_amount"
@@ -825,7 +821,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                    
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         #print("Flag value is {}".format(flagvals)) # For testing.
                         ds = ds.drop("pr_24h_qc")
@@ -833,7 +829,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                         ds['pr_24h_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                         ds['pr_24h_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                        
+
                         ds['pr_24h'].attrs['ancillary_variables'] = "pr_24h_qc" # List other variables associated with variable (QA/QC)
 
                 if "pr_localmid_qc" in ds.keys():
@@ -841,7 +837,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         #print("Flag value is {}".format(flagvals)) # For testing.
                         ds = ds.drop("pr_localmid_qc")
@@ -849,15 +845,15 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                         ds['pr_localmid_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                         ds['pr_localmid_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                        
+
                         ds['pr_localmid'].attrs['ancillary_variables'] = "pr_localmid_qc" # List other variables associated with variable (QA/QC)
-                
+
                 if "pr_qc" in ds.keys():
                     flagvals = ds['pr_qc'].values.tolist()[0]
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         #print("Flag value is {}".format(flagvals)) # For testing.
                         ds = ds.drop("pr_qc")
@@ -865,15 +861,15 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                         ds['pr_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                         ds['pr_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                        
+
                         ds['pr'].attrs['ancillary_variables'] = "pr_qc" # List other variables associated with variable (QA/QC)
-                        
+
                 if "pr_1h_qc" in ds.keys():
                     flagvals = ds['pr_1h_qc'].values.tolist()[0]
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         #print("Flag value is {}".format(flagvals)) # For testing.
                         ds = ds.drop("pr_1h_qc")
@@ -881,7 +877,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                         ds['pr_1h_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                         ds['pr_1h_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                        
+
                         ds['pr_1h'].attrs['ancillary_variables'] = "pr_1h_qc" # List other variables associated with variable (QA/QC)
 
                 if "pr_5min_qc" in ds.keys():
@@ -889,7 +885,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         #print("Flag value is {}".format(flagvals)) # For testing.
                         ds = ds.drop("pr_5min_qc")
@@ -897,36 +893,36 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                         ds['pr_5min_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                         ds['pr_5min_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                        
+
                         ds['pr_5min'].attrs['ancillary_variables'] = "pr_5min_qc" # List other variables associated with variable (QA/QC)
 
-                
+
                 # Set ancillary variables based on other precip cols
                 precip_cols = [elem for elem in ds.keys() if "pr" in elem]
                 precip_cols = [elem for elem in precip_cols if "pressure" not in elem]
-                
+
                 if precip_cols: # if list not empty
                     if len(precip_cols)>1: # If list has more than one var in it.
                         for col in precip_cols:
                             relcols = [k for k in precip_cols if col not in k] # Get list of all vars other than col.
                             ds[col].attrs['ancillary_variables'] = " ".join(relcols)
 
-                
+
                 # hurs: relative humidity
                 if 'relative_humidity_set_1' in ds.keys():
                     ds = ds.rename({'relative_humidity_set_1': 'hurs'})
                     # Set attributes
                     ds['hurs'].attrs['long_name'] = "relative_humidity"
-                    ds['hurs'].attrs['standard_name'] = "relative_humidity" 
-                    ds['hurs'].attrs['units'] = "percent" 
-                    
+                    ds['hurs'].attrs['standard_name'] = "relative_humidity"
+                    ds['hurs'].attrs['units'] = "percent"
+
                     # If QA/QC column exists
                     if 'relative_humidity_set_1_qc' in ds.keys():
                         flagvals = ds['relative_humidity_set_1_qc'].values.tolist()[0]
                         flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                         flagvals = list(np.unique(flagvals)) # Get unique values
                         flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                    
+
                         if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                             #print("Flag value is {}".format(flagvals)) # For testing.
                             ds = ds.drop("relative_humidity_set_1_qc")
@@ -936,14 +932,14 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                             ds['hurs_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                             ds['hurs_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
                             ds['hurs'].attrs['ancillary_variables'] = "hurs_qc" # List other variables associated with variable (QA/QC)
-                            
-                
+
+
                 #rsds: surface_downwelling_shortwave_flux_in_air (solar radiation, w/m2)
-                
+
                 if 'solar_radiation_set_1' in ds.keys(): # Already in w/m2, no need to convert units.
                     # If column exists, rename.
                     ds = ds.rename({'solar_radiation_set_1': 'rsds'})
-                    
+
                     # Set attributes
                     ds['rsds'].attrs['long_name'] = "solar_radiation"
                     ds['rsds'].attrs['standard_name'] = "surface_downwelling_shortwave_flux_in_air"
@@ -955,7 +951,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         ds = ds.drop("solar_radiation_set_1_qc")
                     else:
@@ -963,9 +959,9 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
                         ds['rsds_qc'].attrs['flag_values'] = flagvals # Generate values from unique values from dataset.
                         ds['rsds_qc'].attrs['flag_meanings'] =  "See QA/QC csv for network."
-                        
+
                         ds['rsds'].attrs['ancillary_variables'] = "rsds_qc" # List other variables associated with variable (QA/QC)
-                        
+
 
                 # sfcWind : wind speed (m/s)
                 if "wind_speed_set_1" in ds.keys(): # Data already in m/s.
@@ -977,24 +973,24 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     # (Method of calculation may vary and is unknown source by source.)
                     # See: https://weather.gladstonefamily.net/CWOP_Guide.pdf
                     # FLAG: HOW TO DEAL WITH SOURCE-unique sampling standards in MADIS_clean????
-                
+
                 if 'wind_speed_set_1_qc' in ds.keys():
                     flagvals = ds['wind_speed_set_1_qc'].values.tolist()[0]
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         ds = ds.drop("wind_speed_set_1_qc")
                     else: # Otherwise, rename and reformat.
                         ds = ds.rename({'wind_speed_set_1_qc': 'sfcWind_qc'})
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
-                    
+
                         ds['sfcWind_qc'].attrs['flag_values'] = flagvals
-                        ds['sfcWind_qc'].attrs['flag_meanings'] = "See QA/QC csv for network." 
+                        ds['sfcWind_qc'].attrs['flag_meanings'] = "See QA/QC csv for network."
                         ds['sfcWind'].attrs['ancillary_variables'] = "sfcWind_qc" # List other variables associated with variable (QA/QC)
 
-                
+
                 # sfcWind_dir: wind direction
                 if "wind_direction_set_1" in ds.keys(): # No conversions needed, do not make raw column.
                     ds = ds.rename({'wind_direction_set_1': 'sfcWind_dir'})
@@ -1002,21 +998,21 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     ds['sfcWind_dir'].attrs['standard_name'] = "wind_from_direction"
                     ds['sfcWind_dir'].attrs['units'] = "degrees_clockwise_from_north"
                     ds['sfcWind_dir'].attrs['comment'] = "Wind direction is defined by the direction that the wind is coming from (i.e., a northerly wind originates in the north and blows towards the south)."
-                    
+
                 if 'wind_direction_set_1_qc' in ds.keys():
                     flagvals = ds['wind_direction_set_1_qc'].values.tolist()[0]
                     flagvals = [x for x in flagvals if pd.isnull(x) == False] # Remove nas
                     flagvals = list(np.unique(flagvals)) # Get unique values
                     flagvals = list(np.unique([split_item for item in flagvals for split_item in str(item).split(";")])) # Split any rows with multiple flags and run unique again.
-                
+
                     if flagvals == ['nan']: # This should not occur, but leave in as additional check.
                         ds = ds.drop("wind_direction_set_1_qc")
                     else: # Otherwise, rename and reformat.
                         ds = ds.rename({'wind_direction_set_1_qc': 'sfcWind_dir_qc'})
                         flagvals = [ele.replace(".0", "") for ele in flagvals] # Reformat to match csv.
-                    
+
                         ds['sfcWind_dir_qc'].attrs['flag_values'] = flagvals
-                        ds['sfcWind_dir_qc'].attrs['flag_meanings'] = "See QA/QC csv for network." 
+                        ds['sfcWind_dir_qc'].attrs['flag_meanings'] = "See QA/QC csv for network."
                         ds['sfcWind_dir'].attrs['ancillary_variables'] = "sfcWind_dir_qc" # List other variables associated with variable (QA/QC)
 
                 # Other variables: rename to match format
@@ -1050,7 +1046,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 #Testing: Manually check values to see that they seem correctly scaled, no unexpected NAs.
                 # for var in ds.variables:
                 #     try:
-                #         print([var, float(ds[var].min()), float(ds[var].max())]) 
+                #         print([var, float(ds[var].min()), float(ds[var].max())])
                 #     except:
                 #         next
                 # #Note: here we have tdps and hurs values of 0. This is what causes the "dividing by 0" errors, likely.
@@ -1078,7 +1074,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 rest_of_vars = [i for i in list(ds.keys()) if i not in desired_order] # Retain rest of variables at the bottom.
                 new_index = actual_order + rest_of_vars
                 ds = ds[new_index]
-        
+
 
             except Exception as e:
                 print(traceback.format_exc())
@@ -1092,7 +1088,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
             if ds is None: # Should be caught in error handling above, but add in case.
                 print("{} not saved.".format(file))
                 continue
-            
+
             else:
                 try:
                     filename = station_id+".nc" # Make file name
@@ -1114,7 +1110,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                     errors['File'].append(stat_files)
                     errors['Time'].append(end_api)
                     errors['Error'].append(e)
-                    continue  
+                    continue
 
         # # Write the list of removed variables to csv for future reference. Keep these in one centralized "removedvars.csv" file that gets appended to
         # Read in existing removedvars.csv from AWS folder, if it already exists.
@@ -1134,7 +1130,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
             content = csv_buffer.getvalue()
             s3_cl.put_object(Bucket=bucket_name, Body=content, Key=cleandir+"removedvars.csv")
             # print("Updated removedvars.csv") # For testing
-            
+
         except botocore.exceptions.ClientError as ex:
             if ex.response['Error']['Code'] == 'NoSuchKey': # If removed vars doesn't already exist, save.
                 # Save to AWS
@@ -1143,13 +1139,13 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
                 content = csv_buffer.getvalue()
                 s3_cl.put_object(Bucket=bucket_name, Body=content, Key=cleandir+"removedvars.csv")
                 #print("Created removedvars.csv") # For testing
-                
+
             else: # If some other error occurs.
                 errors['File'].append("Whole network error")
                 errors['Time'].append(end_api)
                 errors['Error'].append(ex.response)
-                
-        
+
+
     # Write errors.csv
     finally: # Always execute this.
         print(errors)
@@ -1159,22 +1155,29 @@ def clean_madis(bucket_name, rawdir, cleandir, network):
         content = csv_buffer.getvalue()
         s3_cl.put_object(Bucket=bucket_name, Body=content, Key=cleandir+"errors_{}_{}.csv".format(network, end_api))
 
-   
+
 # # Run functions
 if __name__ == "__main__":
-    network = "RAWS"
+    # MADIS Networks:
+    # 'CAHYDRO', 'CDEC', 'CNRFC', 'CRN', 'CWOP', 'HADS', 'HNXWFO', 'HOLFUY', 'HPWREN', 'LOXWFO',
+    # 'MAP', 'MTRWFO', 'NCAWOS', 'NOS-NWLON', 'NOS-PORTS', 'RAWS', 'SGXWFO', 'SHASAVAL', 'VCAPCD'
+
+    network = "CAHYDRO"
     rawdir, cleandir, qaqcdir = get_file_paths(network)
-    
+
     get_qaqc_flags(token = config.token, bucket_name = bucket_name, qaqcdir = qaqcdir, network = network)
     clean_madis(bucket_name, rawdir, cleandir, network)
 
-    # # # Testing:
+
+# ---------------------------------------------------------------------------------------------------------
+# Testing
+
     # import random # To get random subsample
     # import s3fs # To read in .nc files
-    
+
     # # # ## Import file.
     # files = []
-    # for item in s3.Bucket(bucket_name).objects.filter(Prefix = cleandir): 
+    # for item in s3.Bucket(bucket_name).objects.filter(Prefix = cleandir):
     #     file = str(item.key)
     #     files += [file]
 
@@ -1186,7 +1189,7 @@ if __name__ == "__main__":
     # # File 1:
     # fs = s3fs.S3FileSystem()
     # aws_urls = ["s3://wecc-historical-wx/"+file for file in files]
-    
+
     # with fs.open(aws_urls[0]) as fileObj:
     #     test = xr.open_dataset(fileObj)
     #     print(test)
@@ -1194,7 +1197,7 @@ if __name__ == "__main__":
     #         print(var)
     #         print(test[var])
     #     test.close()
-        
+
     # # File 2:
     # # Test: multi-year merges work as expected.
     # with fs.open(aws_urls[1]) as fileObj:
@@ -1203,16 +1206,14 @@ if __name__ == "__main__":
     #     print(str(test['time'].max())) # Get end time
     #     test.close()
 
-    
+
     # # File 3:
     # # Test: Inspect vars and attributes
     # with fs.open(aws_urls[2]) as fileObj:
     #     test = xr.open_dataset(fileObj, engine='h5netcdf')
-    #     for var in test.variables: 
+    #     for var in test.variables:
     #         try:
-    #             print([var, float(test[var].min()), float(test[var].max())]) 
+    #             print([var, float(test[var].min()), float(test[var].max())])
     #         except:
     #             continue
     #     test.close()
-    
-    


### PR DESCRIPTION
Fixes an issue in the "CA HYDRO" --> "CAHYDRO" saving process. 

2 files were updated:
- MADIS_sensors in the pull stage, to correctly save the sensor list needed to run the cleaning script for "CAHYDRO". Added a descriptive docstring as to what this script is doing, plus a useful print statement. 
- MADIS_clean in the clean stage, deleted some old testing notes, and added a list of all MADIS networks so that it is easier to run this script with exact naming

**To test**: just run MADIS_sensors and make sure that a sensor list is placed in the 3_qaqc_wx/CAHYDRO folder on AWS (no space!!). Alternatively, can also run MADIS_clean and make sure that it does in fact run when "CAHYDRO" is the network name. 