### PR TITLE
Fix 2 bugs in CIMIS clean

### DIFF
--- a/test_platform/scripts/2_clean_data/CIMIS_clean.py
+++ b/test_platform/scripts/2_clean_data/CIMIS_clean.py
@@ -190,13 +190,6 @@ def clean_cimis(rawdir, cleandir):
                                     df = df.drop(['Hour', 'Date', 'Hour (PST)'], axis = 1)
 
                                     dfs.append(df)
-                                    print(dfs.shape)
-                                    if len(dfs.index) == 0:
-                                        print('No raw data found for {} on AWS.'.format(station_id))
-                                        errors['File'].append(station_id)
-                                        errors['Time'].append(end_api)
-                                        errors['Error'].append('No raw data found for this station on AWS.')
-                                        continue
 
                                 else: # if year csv file does not have data for station, move on to next year
                                     continue
@@ -209,6 +202,12 @@ def clean_cimis(rawdir, cleandir):
 
             try:
                 file_count = len(dfs)
+                if file_count == 0:
+                    print('No raw data found for {} on AWS.'.format(station_id))
+                    errors['File'].append(station_id)
+                    errors['Time'].append(end_api)
+                    errors['Error'].append('No raw data found for this station on AWS.')
+                    continue
                 df_stat = pd.concat(dfs)
 
                 # Drop any columns that only contain NAs.


### PR DESCRIPTION
Fixes two problems:
1. Bad coding (on my end) of an int/str switch, all stations with valid data should now all save
2. Catches a previously missed bad error code that causes station 6 to fail cleaning, meaning we will have one additional cleaned station!

**To test**:  Either run a subset of a handful of stations and make sure everything saves to AWS, or make sure specifically station 6 saves, and station 46 does not (no data)

Code to help test: 
Comment out LN 124
Uncomment Ln 125:  `for station in stations.sample(5): # subset for testing `

**OR**
LN 125: `for station in ['6', '46']:`