### PR TITLE
CW3E dataformat fix

### DIFF
--- a/test_platform/scripts/2_clean_data/CW3E_clean.py
+++ b/test_platform/scripts/2_clean_data/CW3E_clean.py
@@ -191,7 +191,6 @@ def clean_cw3e(rawdir, cleandir):
                                             date_parser = date_parser, dtype={'Temperature (C)':'float64', 'Pressure (mb)':'float64', 'Solar Radiation (W/m^2)':'float64',
                                                                             'Relative Humidity (%)': 'float64', 'Precipitation (mm)': 'float64',
                                                                             'Scalar Wind Speed (m/s)':'float64', "Wind Direction (degrees)":'float64'}, assume_missing=True)
-                            print('pass read in') # psuedo-testing statement to catch where issues reading in are
 
                         except OSError as e: # If year has data, but fails to read-in
                             errors['File'].append(station_id)


### PR DESCRIPTION
This fixes a bug for stations without a DataFormat file, in that I had previously set it to default to the BCC station DataFormat file, but that was failing based on the number of data columns passed. The three stations with no DataFormat file are now handled using a default set of columns (DLA, FRC, CAT). Because these three stations have varying numbers of data columns, the dask dataframe read in was modified to encompass all possible columns, with a more specific remove column drop after read in. To that effect, I also included some handling if a station does not have any data for a particular year - previously it would produce a traceable error and try and process, now it just continues onto the next year of available data. Stations POR and DRW were also producing column errors with the previous set-up, this fix also handles these stations as well. 

Note: The dask dataframe read in modified the process for every station, and is now much more robust handling, but does take a little longer to process data - @bethem was able to run the entire full network successfully with this update. 

**To test**: Specifically test on any station in CW3E (potentially a single station, for time purposes), from any of the following groups: 
1. 6 stations will not have any data on AWS (SKI, SKY, SOD, WDG, WPO, WVY). 
2. DLA, FRC, CAT don't have a dataformat file, but will run now. To test the year handling, CAT and DLA do not have some years of data. FRC has all four years (and will take the longest if selected). 
3. POR and DRW will run, using their native DataFormat files now. POR has 2 years of data, and will complete faster than DRW (which has 4 years of data). 

To test a specific station, modify LN 132 to be the station of your choice to test. Or, if you wanted to test one per group ^ modify to be:
`for station in ['SKI', 'DLA', 'POR']:`
