### PR TITLE
cahydro name needs space to be passed to synoptic

### DIFF
--- a/test_platform/scripts/1_pull_data/update_pull.py
+++ b/test_platform/scripts/1_pull_data/update_pull.py
@@ -212,14 +212,25 @@ def update_ndbc(n, last_time_mod = None):
 # Update script: MADIS
 def update_madis(n, network, last_time_mod = None):
     directory = f'1_raw_wx/{network}/'
-    if last_time_mod is None:
-        last_time_mod = get_last_date(bucket_name, folder = directory, n = int(n[network]), file_ext = '.csv')
+    if network == "CAHYDRO":
+        if last_time_mod is None:
+            last_time_mod = get_last_date(bucket_name, folder = directory, n = int(n[network]), file_ext = '.csv')
     
-    if last_time_mod < download_date:
-        print(f"Downloading {network} data from {last_time_mod} to {download_date}.")
-        madis_update(token= config.token, networks = [network], pause = None, start_date = str(last_time_mod), end_date = str(download_date))
-    else:
-        print(f"{network} station files up to date.")
+        if last_time_mod < download_date:
+            print(f"Downloading {network} data from {last_time_mod} to {download_date}.")
+            madis_update(token= config.token, networks = ["CA HYDRO"], pause = None, start_date = str(last_time_mod), end_date = str(download_date))
+        else:
+            print(f"{network} station files up to date.")
+
+    else: # all other MADIS networks
+        if last_time_mod is None:
+            last_time_mod = get_last_date(bucket_name, folder = directory, n = int(n[network]), file_ext = '.csv')
+        
+        if last_time_mod < download_date:
+            print(f"Downloading {network} data from {last_time_mod} to {download_date}.")
+            madis_update(token= config.token, networks = [network], pause = None, start_date = str(last_time_mod), end_date = str(download_date))
+        else:
+            print(f"{network} station files up to date.")
 
 
 if __name__ == "__main__":
@@ -234,4 +245,4 @@ if __name__ == "__main__":
     #update_cw3e(n)
     #update_maritime(n)
     #update_ndbc(n)
-    #update_madis(n, network = 'VCAPCD')
+    update_madis(n, network = 'CAHYDRO')


### PR DESCRIPTION
This addresses the name spacing issue in the "CAHYDRO" network for the pull update script. 

In short, the network name's is actually CA HYDRO (with space). But on AWS issues arise with saving data to the bucket(s) with the space, so we've reduced it to CAHYDRO (no space), however with the pull script it could see the data on our AWS bucket to grab, but could not pass CAHYDRO (no space) to Synoptic to pull data since Synoptic has it coded with its actual name CA HYDRO (with space). 

Fix just ensures that CA HYDRO (with space) is passed to Synoptic if CAHYDRO (no space) is passed in script as the network name. 

**To test**: Just run update_pull as is. It's set up for CAHYDRO (no space) to grab CA HYDRO (with space) data. 

CAHYDRO CA HYDRO CAHYDRO CA HYDRO lol. 