### PR TITLE
Fix for problematic files in CW3E pull

### DIFF
--- a/test_platform/scripts/1_pull_data/CW3E_pull.py
+++ b/test_platform/scripts/1_pull_data/CW3E_pull.py
@@ -297,7 +297,10 @@ if __name__ == "__main__":
     # To get station list, run:
     get_cw3e_metadata(token = config.token, terrpath = wecc_terr, marpath = wecc_mar, bucket_name = bucket_name, directory = "1_raw_wx/CW3E/")
     # To download all data, run:
-    # get_cw3e(bucket_name, directory)
+    get_cw3e(bucket_name, directory)
+    
+    # To download updated data, run:
+    # get_cw3e_update(bucket_name, directory)
 
     #-----------------------------------------------------------------------------------------------------------------------------------------
     # Example uses
@@ -305,6 +308,6 @@ if __name__ == "__main__":
     # ge_cw3e(bucket_name, directory, station=["PVN"])
 
     # Specific station and start date/end date in update pull
-    get_cw3e_update(bucket_name, directory, station=["FRC", "WDG"], start_date="2021-01-24", end_date="2021-01-26")
+    # get_cw3e_update(bucket_name, directory, station=["FRC", "WDG"], start_date="2021-01-24", end_date="2021-01-26")
 
     


### PR DESCRIPTION
tl;dr: Updates handling for the 2 random files that should be directories but are missing data issue. 

CW3E data is saved on their server as each station consists of yearly directories, with folders for each day, and 24 hourly files for each day within each day folder (aka: STATION > YEAR > DAY > HOURLY FILES). Two stations (FRC and WDG) have a data gap for day 025 in 2021, in that there is not a directory folder for the 25th day but instead a single file that is not named according to their structure is provided. This previously unintentionally broke our scripts by either skipping substantial amounts of data or killing the script all together with no error warning. 

This update now identifies if this issue occurs, attempts to download the solo file and renames it according to their naming structure, and if unable to download, throws an error that will get saved to our error files. 

To test: comment out LN 300, and  uncomment LN 311 and run
It is set up for these two stations and will grab the day before and the day after's data. Ensure that a "025.23m" file saves for both stations (should be a "frc21025.23m" and "wdg21025.23m" files)