### PR TITLE
delete subsetting for full run

### DIFF
--- a/test_platform/scripts/2_clean_data/MADIS_clean.py
+++ b/test_platform/scripts/2_clean_data/MADIS_clean.py
@@ -312,8 +312,6 @@ def clean_madis(bucket_name, rawdir, cleandir, network, cwop_letter = None):
         else: # network should not be CWOP, and will complete full clean
             ids = ids 
 
-        ids = sample(ids, 3) # testing, to be removed once batch-cleaning process approved
-
         for i in ids:
             try:
                 stat_files = [k for k in files if i in k] # Get list of files with station ID in them.


### PR DESCRIPTION
Deletes a subsetting single line of code that I forgot to remove in the MADIS_clean script

To test: doesn't need to be actually run (would strongly not recommend that), just look over the change