### PR TITLE
Clean variable coverage: switch to all variables

### DIFF
--- a/test_platform/scripts/2_clean_data/stnlist_update_clean.py
+++ b/test_platform/scripts/2_clean_data/stnlist_update_clean.py
@@ -292,7 +292,7 @@ def clean_qa(network, clean_var_add=False):
 
 
 if __name__ == "__main__":
-    clean_qa('SHASAVAL', clean_var_add=True)
+    clean_qa('SHASAVAL', clean_var_add=False)
 
 
     # List of all stations for ease of use here:


### PR DESCRIPTION
This PR switches the variable Y/N flag and observation counts for all variables, and not grouping the precipitation (4 vars), pressure (4 vars), and dew point temperature (2 vars) together. 

**To test**
Run the stnlist_update_clean script on any network of choice with the clean_var_add flag turned to True. 
- Recommend picking a smaller network to test on (pretty much, not CIMIS, CW3E, HADS, RAWS, CWOP)
- SHASAVAL, VCAPCD, NOS-PORTS, NOS-NWLON, NDBC, MARITIME should be fairly quick