### PR TITLE
Timeout error fix for cleaning BIG stations

### DIFF
--- a/test_platform/scripts/2_clean_data/MADIS_clean.py
+++ b/test_platform/scripts/2_clean_data/MADIS_clean.py
@@ -187,11 +187,10 @@ def parse_madis_to_pandas(file, headers, errors, removedvars):
     # Handling for timeout errors
     # If a timeout occurs, the last line of valid data is repeated in the next file and is skipped, but if that is the only line of data, script breaks
     # Remove "status" error rows
-    if len(df[df.isin(['{"status": 408']).any(axis=1)]) != 0:
+    if len(df[df.isin([' "message": "Request could not complete. Timeout."}']).any(axis=1)]) != 0:
         df = df.drop(df.tail(1).index)
-
-    # df = df.loc[df["Station_ID"].str.contains("status")==False]
-    # df = df.loc[df["Date_Time"].str.contains("message")==False]
+    elif len(df[df.isin(['{"status": 408']).any(axis=1)]) != 0:
+        df = df.drop(df.tail(1).index)
 
     # Drop any columns that only contain NAs.
     df = df.dropna(axis = 1, how = 'all')
@@ -1224,7 +1223,7 @@ def clean_madis(bucket_name, rawdir, cleandir, network, cwop_letter = None):
 
 # # Run functions
 if __name__ == "__main__":
-    network = "RAWS"
+    network = "CWOP"
     rawdir, cleandir, qaqcdir = get_file_paths(network)
     print(rawdir, cleandir, qaqcdir)
     get_qaqc_flags(token = config.token, bucket_name = bucket_name, qaqcdir = qaqcdir, network = network)


### PR DESCRIPTION
This has plagued us since our first full clean - stations with timeout errors were not behaving in the cleaning process, leaving out some really large stations. 

---
To test:
- Change Ln 322 in  MADIS_clean.py to the following to target the two problematic stations in the "A" group that we are aware of (there's a bunch in "C" "D", and "E" too)
`for i in ['AP907', 'AS234']:` 
You can also subset by setting cwop_letter = "A" in Ln 1230 but only those 2 stations will run with Ln 322 changed, so this is not necessary