### PR TITLE
Time index de-duplication pre qaqc pipeline

### DIFF
--- a/test_platform/scripts/3_qaqc_data/QAQC_pipeline.py
+++ b/test_platform/scripts/3_qaqc_data/QAQC_pipeline.py
@@ -215,7 +215,10 @@ def run_qaqc_pipeline(ds, network, file_name,
     df = ds.to_dataframe()
     df['anemometer_height_m'] = np.ones(ds['time'].shape)*ds.anemometer_height_m
     df['thermometer_height_m'] = np.ones(ds['time'].shape)*ds.thermometer_height_m
-    
+
+    # De-duplicate time axis
+    df = df[~df.index.duplicated()].sort_index()
+                          
     # Save station/time multiindex
     MultiIndex = df.index
     station = df.index.get_level_values(0)


### PR DESCRIPTION
This branch de-duplicates time index in the pandas dataframe before the qaqc pipeline is run. The only line added before starting the qaqc pipeline, and before removing `station` and `time` index is this:
`df = df[~df.index.duplicated()].sort_index()`
The same line is also at the end of the pipeline, it might be redundant to keep it at the end. Keeping for now.