### PR TITLE
QA/QC: add rsds min-max to world records check + plot functions

### DIFF
--- a/test_platform/scripts/3_qaqc_data/qaqc_plot.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_plot.py
@@ -84,11 +84,13 @@ def _plot_format_helper(var):
     W_N = {"North_America":0.}     #m/s
     S_X = {"North_America":108330} #Pa
     S_N = {"North_America":87000}  #Pa
+    R_X = {"North_America":1500}   #W/m2
+    R_N = {"North_America":-5}     #W/m2
 
     maxes = {"tas": T_X, "tdps": D_X, "tdps_derived": D_X, "sfcWind": W_X, 
-             "psl": S_X, "ps": S_X, "ps_altimeter": S_X}
+             "psl": S_X, "ps": S_X, "ps_altimeter": S_X, "rsds":R_X}
     mins =  {"tas": T_N, "tdps": D_N, "tdps_derived": D_N, "sfcWind": W_N, 
-             "psl": S_N, "ps": S_N, "ps_altimeter": S_N}
+             "psl": S_N, "ps": S_N, "ps_altimeter": S_N, "rsds": R_N}
     miny = mins[var]['North_America']
     maxy = maxes[var]['North_America']
     

--- a/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
@@ -427,13 +427,17 @@ def qaqc_world_record(df, verbose=True):
         if failure:
             None
 
+    References:
+    -----------
+        1. World records from HadISD protocol, cross-checked with WMO database
+        2. https://wmo.asu.edu/content/world-meteorological-organization-global-weather-climate-extremes-archive
+        3. Solar radiation specific: Rupp et al. 2022, Slater 2016
+
     Flag meaning:
     -------------
         11,qaqc_world_record,Value outside of world record range
     '''
     try:
-        # world records from HadISD protocol, cross-checked with WMO database
-        # https://wmo.asu.edu/content/world-meteorological-organization-global-weather-climate-extremes-archive
         T_X = {"North_America":329.92} #K
         T_N = {"North_America":210.15} #K
         D_X = {"North_America":329.85} #K
@@ -442,12 +446,14 @@ def qaqc_world_record(df, verbose=True):
         W_N = {"North_America":0.} #m/s
         S_X = {"North_America":108330} #Pa
         S_N = {"North_America":87000} #Pa
+        R_X = {"North_America":1500} #W/m2
+        R_N = {"North_America":-5} #W/m2
 
-        maxes = {"tas": T_X, "tdps": D_X, "tdps_derived": D_X, "sfcWind": W_X, "psl": S_X}
-        mins = {"tas": T_N, "tdps": D_N, "tdps_derived": D_N, "sfcWind": W_N, "psl": S_N}
+        maxes = {"tas": T_X, "tdps": D_X, "tdps_derived": D_X, "sfcWind": W_X, "psl": S_X, "rsds": R_X}
+        mins = {"tas": T_N, "tdps": D_N, "tdps_derived": D_N, "sfcWind": W_N, "psl": S_N, "rsds": R_N}
 
         # variable names to check against world record limits
-        wr_vars = ['tas', 'tdps_derived', 'tdps', 'sfcWind', 'psl']
+        wr_vars = ['tas', 'tdps_derived', 'tdps', 'sfcWind', 'psl', 'rsds']
 
         for var in wr_vars:
             if var in list(df.columns):


### PR DESCRIPTION
Adds solar radiation min max values into the world records check to flag. 
Values are based on -1 to 1500 W/m2 (Rupp et al. 2022) and -5 to 1400 W/m2 (Slater 2016)

---
*To Test*:
Run on any station with solar radiation :) 