### PR TITLE
QA/QC: updates clim outlier plot so it doesn't fail

### DIFF
--- a/test_platform/scripts/3_qaqc_data/qaqc_climatological_outlier.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_climatological_outlier.py
@@ -111,7 +111,6 @@ def qaqc_climatological_outlier(df, winsorize=True, winz_limits=[0.05,0.05], plo
                     # May be later reinstated on comparison with good data from neighboring stations
 
                 for month in range(1,13):
-
                     df_m = df_std.loc[df_valid['month'] == month]
 
                     # some months will be missing data
@@ -120,7 +119,6 @@ def qaqc_climatological_outlier(df, winsorize=True, winz_limits=[0.05,0.05], plo
 
                     # determine number of bins
                     bins = create_bins(df_m[var])
-
                     # pdf
                     mu = np.nanmean(df_m[var])
                     sigma = np.nanstd(df_m[var])
@@ -140,11 +138,10 @@ def qaqc_climatological_outlier(df, winsorize=True, winz_limits=[0.05,0.05], plo
                                 for i in idx_to_flag:
                                     df.loc[df.index == i, var+'_eraqc'] = 26 # see era_qaqc_flag_meanings.csv 
 
-            if plot:
-                for var in vars_to_anom:
-                    for month in range(1,13):
+                    if plot:
                         if 26 in df[var+'_eraqc'].values: # only plot a figure if flag is present
                             clim_outlier_plot(df, var, month, network=df['station'].unique()[0].split('_')[0], local=local) 
+
         # Drop month,year vars used for calculations
         df = df.drop(columns=['hour','month','year'])
         return df

--- a/test_platform/scripts/3_qaqc_data/qaqc_plot.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_plot.py
@@ -586,11 +586,12 @@ def clim_outlier_plot(df, var, month, network, dpi=None, local=False):
     '''
     
     # select month
-    df_to_plot = df.loc[pd.to_datetime(df.time).dt.month == month][var]
+    df['time'] = pd.to_datetime(df['time'], errors='coerce')
+    df_to_plot = df.loc[df.time.dt.month == month][var]
     
     # determine number of bins
     bins = create_bins(df_to_plot)
-    
+
     # plot histogram
     ax = plt.hist(df_to_plot, bins=bins, log=False, density=True, color='k', alpha=0.3)
     xmin, xmax = plt.xlim()
@@ -604,22 +605,23 @@ def clim_outlier_plot(df, var, month, network, dpi=None, local=False):
     
     # add vertical lines to indicate thresholds where pdf y=0.1
     pdf_bounds = np.argwhere(y > 0.1)
-    
-    # find first index
-    left_bnd = round(bins[pdf_bounds[0][0] - 1])
-    right_bnd = round(bins[pdf_bounds[-1][0] + 1])
-    thresholds = (left_bnd, right_bnd)
-    
-    plt.axvline(thresholds[1], color='r') # right tail
-    plt.axvline(thresholds[0], color='r') # left tail
-    
-    # flag visually obs that are beyond threshold
-    for bar in ax[2].patches:
-        x = bar.get_x() + 0.5 * bar.get_width()
-        if x > thresholds[1]: # right tail
-            bar.set_color('r')
-        elif x < thresholds[0]: # left tail
-            bar.set_color('r')
+    if len(pdf_bounds) != 0: # placing in if/else statement for time being as this figure/fn is refined
+        
+        # find first index
+        left_bnd = round(bins[pdf_bounds[0][0] - 1])
+        right_bnd = round(bins[pdf_bounds[-1][0] + 1])
+        thresholds = (left_bnd, right_bnd)
+        
+        plt.axvline(thresholds[1], color='r') # right tail
+        plt.axvline(thresholds[0], color='r') # left tail
+        
+        # flag visually obs that are beyond threshold
+        for bar in ax[2].patches:
+            x = bar.get_x() + 0.5 * bar.get_width()
+            if x > thresholds[1]: # right tail
+                bar.set_color('r')
+            elif x < thresholds[0]: # left tail
+                bar.set_color('r')
             
     # title and useful annotations
     plt.title('Climatological outlier check, {0}: {1}'.format(df['station'].unique()[0], var), fontsize=10);
@@ -643,11 +645,10 @@ def clim_outlier_plot(df, var, month, network, dpi=None, local=False):
                      directory, network, figname))
 
     if local:
-        fig.savefig('qaqc_figs/{}.png'.format(figname), format='png', dpi=dpi, bbox_inches="tight")
+        plt.savefig('qaqc_figs/{}.png'.format(figname), format='png', dpi=dpi, bbox_inches="tight")
 
     # close figures to save memory
-    plt.close(fig)
-    plt.close('all')
+    plt.close()
 
     return
 


### PR DESCRIPTION
This is a temporary fix - the climatological outliers plot needs refinement (time-intensive), so this modifies the plotting so that an error is not thrown, the variable is still flagged appropriately, and a plot is produced (just not the full flagged version). 