### PR TITLE
QAQC Bug: precip_logic_nonegavals fix

### DIFF
--- a/test_platform/scripts/3_qaqc_data/qaqc_logic_checks.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_logic_checks.py
@@ -248,8 +248,10 @@ def qaqc_precip_logic_nonegvals(df, verbose=False):
         else:
             for item in pr_vars:
                 df_valid = grab_valid_obs(df_neg_pr, item)  # subset for valid obs
-                df_valid.loc[df_valid[item] < 0, item + "_eraqc"] = 10  # see era_qaqc_flag_meanings.csv
-                
+                df_valid.loc[df_valid[item] < 0, item + "_eraqc"] = (
+                    10  # see era_qaqc_flag_meanings.csv
+                )
+
         return df_valid
 
     except Exception as e:


### PR DESCRIPTION
## Summary of changes & context
Updated which dataframe the flags were being set on in this one test. 

## How to test 
Run QA/QC pipeline on a valleywater station -- particularly 6001 to see if the test fails the logic test

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] None of the above  

## To-Do
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] Delete branch once PR is merged in
