### PR TITLE
Default to always write to zarr

### DIFF
--- a/test_platform/scripts/3_qaqc_data/QAQC_pipeline.py
+++ b/test_platform/scripts/3_qaqc_data/QAQC_pipeline.py
@@ -376,16 +376,16 @@ def process_output_ds(
             filename = station + ".zarr"
         filepath = qaqcdir + filename  # Writes file path
 
-        if local == True:
+        if local == True or zarr == False:
             tmpFile = tempfile.NamedTemporaryFile(
                 dir="./temp/", prefix="_" + station, suffix=".nc", delete=False
             )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=RuntimeWarning)
+                ds.to_netcdf(tmpFile.name)  # Save station file.
 
         # Push file to AWS with correct file name
         t0 = time.time()
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=RuntimeWarning)
-            ds.to_netcdf(tmpFile.name)  # Save station file.
         logger.info(
             "Saving/pushing {0} with dims {1} to {2}".format(
                 filename, ds.dims, bucket_name + "/" + qaqcdir


### PR DESCRIPTION
## Summary of changes & context
Default to always write to zarr, even if the input is a netcdf file. 

## How to test 
Test with any station that doesn't have zarrs in the second folder (i.e. anything but Valley Water). Make sure a zarr uploads. 

For example: 
```
python ALLNETWORKS_qaqc.py -n="ASOS_AWOS"
```

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] None of the above  

## To-Do
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [] Delete branch once PR is merged in
