### PR TITLE
Word Record Bug

### DIFF
--- a/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
@@ -558,7 +558,7 @@ def qaqc_world_record(df, verbose=False):
     [5] https://www.weather.gov/media/owp/oh/hdsc/docs/TP2.pdf
     """
 
-    print("Running: qaqc_world_record")
+    logger.info("Running: qaqc_world_record")
 
     try:
         T_X = {"North_America": 329.92}  # temperature, K
@@ -677,15 +677,15 @@ def qaqc_world_record(df, verbose=False):
                     df.loc[df.index.isin(isOffRecord_true.index), var + "_eraqc"] = (
                         11  # see era_qaqc_flag_meanings.csv
                     )
-                    print(
+                    logger.info(
                         "Flagging {} observations exceeding world/regional records: {}".format(
-                            sum(isOffRecord_true), var
+                            sum(isOffRecord), var
                         )
                     )
 
         return df
     except Exception as e:
-        print(
+        logger.info(
             "qaqc_world_record failed with Exception: {}".format(e),
         )
         return None


### PR DESCRIPTION
## Summary of changes & context
Modified qaq_world_record function in qaqc_wholestation:

- removed repeat "pr_24h" from wr_vars
- added "pr_localmid" and "accum_pr" tp wr_vars
- modified isOffRecord check so that rows of df corresponding only with true values in isOffRecord are flagged (see "isOffRecord_true" variable addition)

## How to test 
Run on a problem station like CNFRC_SAPC1 and compare "<variable>_eraqc" columns before after after. Values within the world record ranges should remain unflagged.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] None of the above  

## To-Do
- [x] Documentation
  - [ ] Intent of all functions included
  - [x] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [ ] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [ ] Delete branch once PR is merged in
