### PR TITLE
QA/QC: add lone peak flag [VW only]

### DIFF
--- a/test_platform/scripts/3_qaqc_data/era_qaqc_flag_meanings.csv
+++ b/test_platform/scripts/3_qaqc_data/era_qaqc_flag_meanings.csv
@@ -34,3 +34,4 @@
 33,qaqc_unusual_gaps_precip,Value flagged as an unusual gap in values in the daily precipitation check
 34,qaqc_deaccumulate_precip,Value flagged has a period of oscillating values (probably sensor malfunction producing ringing-like data) in the accumulated precipitation (that would result on incorrect/false de-accumulated values that look correct): cannot determine which value (higher or lower) is the real one (it has been also converted to nan in the deaccumulated series)
 35,qaqc_deaccumulate_precip,Original precipitation data; deaccumulation process has been applied
+37,VALLEYWATER_qaqc_custom,Lone peak identified in precipitation (single observation >= 5.08mm with no other precip obs in +/- 6hr window)


### PR DESCRIPTION
## Summary of changes & context
Relevant to https://github.com/Eagle-Rock-Analytics/valley-water/pull/18. 
QA/QC lone peak function identifies single precip obs greater than 0.2" with no other precip obs within a 6-hour surrounding window; indicative of a instrumentation error.

## How to test 
No need to test -- @JesseEspinoza is on it. Largely adding for documentation purposes, since VW runs on HDP qa/qc code. This flag is not being incorporated into HDP. PR will be merged in once #211 is merged in, as there will be a merge conflict with rows in the csv.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] None of the above  

## To-Do
- [ ] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [ ] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] Delete branch once PR is merged in
