### PR TITLE
QA/QC bug fix: elevation internal consistency was failing for stations with one elevation value

### DIFF
--- a/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
@@ -320,7 +320,9 @@ def qaqc_elev_internal_range_consistency(df, verbose=False):
                     )
         else:
             # only a single elevation value present
-            logger.info("Only a single elevation value present -- bypassing qaqc_elev_internal_range_consistency check")
+            logger.info(
+                "Only a single elevation value present -- bypassing qaqc_elev_internal_range_consistency check"
+            )
 
         return df
 


### PR DESCRIPTION
## Summary of changes & context
Switched the logic for the if/else statement to determine the internal consistency check.

## How to test 
Test on an ASOSAWOS station (2+ elevations typicaly included) **and** a non-ASOSAWOS station, like CDEC_BLB

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [x] All unneccessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] Delete branch once PR is merged in
