### PR TITLE
Ensure proper shutdown of script

### DIFF
--- a/test_platform/scripts/3_qaqc_data/QAQC_pipeline.py
+++ b/test_platform/scripts/3_qaqc_data/QAQC_pipeline.py
@@ -19,6 +19,7 @@ import pandas as pd
 import xarray as xr
 import boto3
 import s3fs
+import sys
 from io import StringIO
 import time
 import tempfile
@@ -1392,5 +1393,13 @@ def whole_station_qaqc(
             for handler in logger.handlers:
                 handler.close()
                 logger.removeHandler(handler)
+
+        # Finalize the MPI environment and ensure proper shutdown of logging and standard output streams
+        if "smpi" in locals():
+            smpi.finalize()  # Finalize the MPI environment to clean up any active MPI resources
+        logging.shutdown()  # Ensure that all log messages are written and handlers are closed
+        sys.stdout.flush()  # Flush any buffered data in the standard output stream
+        sys.stderr.flush()  # Flush any buffered data in the standard error stream
+        sys.exit(0)  # Exit the script with a successful termination status (0)
 
     return None


### PR DESCRIPTION
## Summary of changes & context
The issue occurred when running an MPI-based Python script on a cluster, where the job would complete execution but fail to properly shut down, causing the job to hang indefinitely. This happened because the script did not properly finalize the MPI environment or flush the logging and output streams, preventing the job from completing and allowing the cluster to recognize the task as finished. The solution was to explicitly finalize MPI, flush both the standard output and error streams, shut down the logging handlers, and exit the script gracefully to ensure proper termination.

## How to test 
n/a. No meaningful changes to the code occurred; the added code just shuts down the script (see explanation above). Applicable only to runs in the pcluster. 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [ ] All unneccessary files are removed from this PR (no station files or stationlist csvs!)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Black formatting has been utilized
- [ ] Tagged/notified at least 1 reviewer for this PR
- [ ] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [ ] Delete branch once PR is merged in
