### PR TITLE
flagged_timeseries_plot bug for accum_pr vars fixed

### DIFF
--- a/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
@@ -892,9 +892,8 @@ def flag_summary(df):
 
     # identify _eraqc variables
     eraqc_vars = [var for var in df.columns if "_eraqc" in var]
-    obs_vars = [item.split("_e")[0] for item in eraqc_vars]
-    # Ignore originally accumulated variables (pr)
-    obs_vars = [var for var in obs_vars if "accum" not in var]
+    # Select obs variables to plot and ignore originally accumulated variables (pr)
+    obs_vars = [item.split("_e")[0] for var in eraqc_vars if "accum" not in var]
 
     for var in eraqc_vars:
         logger.info(


### PR DESCRIPTION
## Summary of changes & context
`flagged_timeseries_plot` function bug for accum precip variables fixed

## How to test 
Run pipeline on any station with accumulated precip (for example VALLEYWATER_SVA)
`python3 QAQC_run_for_single_station.py --station VALLEYWATER_SVA`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [x] All unneccessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [ ] Delete branch once PR is merged in
