### PR TITLE
Fix typo in flags_summary

### DIFF
--- a/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_wholestation.py
@@ -893,7 +893,7 @@ def flag_summary(df):
     # identify _eraqc variables
     eraqc_vars = [var for var in df.columns if "_eraqc" in var]
     # Select obs variables to plot and ignore originally accumulated variables (pr)
-    obs_vars = [item.split("_e")[0] for var in eraqc_vars if "accum" not in var]
+    obs_vars = [var.split("_e")[0] for var in eraqc_vars if "accum" not in var]
 
     for var in eraqc_vars:
         logger.info(


### PR DESCRIPTION
## Summary of changes & context
This typo was causing qaqc to fail with error: run_qaqc_pipeline failed with error: name 'item' is not defined

## How to test 
Test on a station of your choice

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [x] Documentation: 
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [x] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] I agree to delete the branch once it's merged to main 
