### PR TITLE
Bug/type hints

### DIFF
--- a/test_platform/scripts/3_qaqc_data/log_config.py
+++ b/test_platform/scripts/3_qaqc_data/log_config.py
@@ -22,7 +22,7 @@ def setup_logger(
 
     Returns
     -------
-    logger : logging.logger
+    logger : logging.Logger
         Information to be sent to logger / log file
     """
 
@@ -54,12 +54,12 @@ def setup_logger(
 
 
 # -----------------------------------------------------------------------------
-def remove_file_handler_by_filename(logger: logging.logger, filename: str):
+def remove_file_handler_by_filename(logger: logging.Logger, filename: str):
     """Remove a specific FileHandler from the logger by matching the filename.
 
     Parameters
     ----------
-    logger : logging.logger
+    logger : logging.Logger
         Input logger handler
     filename : str
         Filename of logger handler

--- a/test_platform/scripts/3_qaqc_data/qaqc_utils.py
+++ b/test_platform/scripts/3_qaqc_data/qaqc_utils.py
@@ -510,7 +510,7 @@ def get_filenames_in_s3_folder(bucket: str, folder: str) -> list:
 # -----------------------------------------------------------------------------
 def get_wecc_poly(
     terrpath: str, marpath: str
-) -> tuple[gp.polygon, gp.polygon, gp.polygon]:
+) -> tuple[gp.GeoDataFrame, gp.GeoDataFrame, pd.DataFrame]:
     """Identifies a bbox of WECC area to filter stations against.
 
     Parameters
@@ -522,11 +522,11 @@ def get_wecc_poly(
 
     Returns
     -------
-    t : gp.polygon
+    t : gp.GeoDataFrame
         spatial object for terrestrial boundary
-    m : gp.polygon
+    m : gp.GeoDataFrame
         spatial object for maritime boudary
-    bbox : gp.polygon
+    bbox : pd.DataFrame
         bounding box for union of t and m
     """
     t = gp.read_file(terrpath)  ## Read in terrestrial WECC shapefile.


### PR DESCRIPTION
## Summary of changes & context
A few incorrectly formatted typehints caused the compiler to fail when actually running the QAQC scripts. Also updated a dropped docstring. 

## How to test 
Either just review changes, or run the `QAQ_run_for_single_station` on a station of choice (PM approval granted). @vicford has tested on 2 stations that needed to be re-run. 

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] None of the above  

## To-Do
- [ ] Documentation: 
  - [ ] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [x] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [ ] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [ ] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] I agree to delete the branch once it's merged to main 
