### PR TITLE
Updating final bugs for staiton concatenation

### DIFF
--- a/test_platform/scripts/3_qaqc_data/station_matching.ipynb
+++ b/test_platform/scripts/3_qaqc_data/station_matching.ipynb
@@ -665,7 +665,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def concatenate_stations(network_name: str) -> list[str]:\n",
+    "def concatenate_stations(network_name: str) -> None:\n",
     "    \"\"\"\n",
     "    Coordinates the concatenation of input datasets and exports the final concatenated dataset.\n",
     "    Also returns a list of the ERA-IDs of all stations that are concatenated.\n",
@@ -677,8 +677,7 @@
     "\n",
     "    Returns\n",
     "    -------\n",
-    "    if success: return a list of strings\n",
-    "    if failure: None\n",
+    "    None\n",
     "    \n",
     "    Notes\n",
     "    -----\n",
@@ -703,15 +702,14 @@
     "        concat_list.concat_subset.str.contains(network_name)\n",
     "    ]\n",
     "\n",
-    "    ####### for testing\n",
+    "    ####### if need for specific station or for subsetting\n",
     "    # concat_by_network = concat_list[concat_list['concat_subset'] == \"MARITIME_1\"]\n",
-    "    ####### for testing\n",
+    "    ####### \n",
     "    \n",
     "    unique_pair_names = concat_by_network.concat_subset.unique()\n",
     "    # For MARITIME, remove these stations becuase they're actually separate stations\n",
     "    if network_name == 'MARITIME':\n",
     "        unique_pair_names = unique_pair_names[1:]\n",
-    "        # unique_pair_name = unique_pair_name[~unique_pair_name[\"ERA-ID\"].isin['MARITIME_LJPC1','MARITIME_LJAC1']]\n",
     "    else: \n",
     "        pass\n",
     "\n",
@@ -789,9 +787,7 @@
     "        # Export final dataset\n",
     "        concat_export(ds_concat, network_name, station_name_new)\n",
     "\n",
-    "        print(f\"\\nConcatenated stations: {final_concat_list}\")\n",
-    "\n",
-    "    return final_concat_list"
+    "    return None"
    ]
   },
   {
@@ -813,6 +809,13 @@
     "final_concat_list = concatenate_stations(network_name)\n",
     "final_concat_list"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary of changes & context
Handful of bugs fixed, large changes were that the export and renaming of the concatenated files was overhauled. 

## How to test 
No testing -  it overwrites files. It would require re-QA/QCing the original stations and then re-running. 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [x] Documentation: 
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [x] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [x] Black formatting has been utilized
- [N/A -- former PR] Tagged/notified at least 1 reviewer for this PR
- [x] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] I agree to delete the branch once it's merged to main 
