### PR TITLE
Resolving variable names mismatch for BUCKET_NAME, QAQC_WX

### DIFF
--- a/test_platform/scripts/3_qaqc_data/stnlist_update_qaqc.py
+++ b/test_platform/scripts/3_qaqc_data/stnlist_update_qaqc.py
@@ -76,7 +76,7 @@ def get_qaqc_stations(network: str) -> pd.DataFrame:
 
     # Construct the S3 path prefix for the network inside the QAQC folder
 
-    parent_s3_path = f"{bucket_name}/{qaqc_wx}{network}"
+    parent_s3_path = f"{BUCKET_NAME}/{QAQC_WX}{network}"
 
     # Use s3fs to list all items under this path
     s3_fs = s3fs.S3FileSystem(anon=False)
@@ -123,11 +123,11 @@ def parse_error_csv(network: str) -> pd.DataFrame:
     errordf = []  # List to store all non-empty error DataFrames found
 
     # Define the path prefix in the S3 bucket for error CSVs
-    errors_prefix = f"{qaqc_wx}{network}/qaqc_errs/errors"
+    errors_prefix = f"{QAQC_WX}{network}/qaqc_errs/errors"
 
     # Loop over all objects in the specified S3 prefix
-    for item in s3.Bucket(bucket_name).objects.filter(Prefix=errors_prefix):
-        obj = s3_cl.get_object(Bucket=bucket_name, Key=item.key)
+    for item in s3.Bucket(BUCKET_NAME).objects.filter(Prefix=errors_prefix):
+        obj = s3_cl.get_object(Bucket=BUCKET_NAME, Key=item.key)
         errors = pd.read_csv(obj["Body"])
         if errors.empty:  # If file empty
             continue
@@ -287,7 +287,7 @@ def qaqc_qa(network: str):
 
 # ---------------------------------------------------------------------------------------------------------------------------------------------
 if __name__ == "__main__":
-    qaqc_qa("CIMIS")
+    qaqc_qa("ASOSAWOS")
 
     # List of all stations for ease of use here:
     # ASOSAWOS, CAHYDRO, CIMIS, CW3E, CDEC, CNRFC, CRN, CWOP, HADS, HNXWFO, HOLFUY, HPWREN, LOXWFO


### PR DESCRIPTION
## Summary of changes & context
It looks like the variables BUCKET_NAME and QAQC_WX were not updated in some parts of the last PR for stnlist_update_qaqc.py (this could have been during resolving the merge conflict). This PR updates the script so that all parts of the script should now be using BUCKET_NAME and QAQC_WX not bucket_name and qaqc_wx.

## How to test 
Pick a station of choice and run the script. Check to see if it encounters any errors and if the stationlist_NETWORK_qaqc.csv file populates correctly.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [X] Documentation: 
  - [X] Complex code commented
  - [X] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [X] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [X] Black formatting has been utilized
- [X] Tagged/notified at least 1 reviewer for this PR
- [X] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [X] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [X] I agree to delete the branch once it's merged to main 
