### PR TITLE
Adds "QC_Time" from zarr path to stationlist_NETWORK_qaqc

### DIFF
--- a/test_platform/scripts/3_qaqc_data/stnlist_update_qaqc.py
+++ b/test_platform/scripts/3_qaqc_data/stnlist_update_qaqc.py
@@ -77,7 +77,7 @@ def get_zarr_last_mod(fn: str) -> str:
     """
 
     # Grab only path name without extension or bucket name
-    path_no_ext = fn.split(".")[0]  
+    path_no_ext = fn.split(".")[0]
     path_no_bucket = path_no_ext.split(BUCKET_NAME)[-1][1:]
 
     # idenitfy last_modified date from metadata date within .zarr


### PR DESCRIPTION
## Summary of changes & context
Adds support function that identifies the "last_modified" date from a zarr, so that it can be updated in the QAQC stationlist. Subsetting of the filename string could be cleaner, but it does the job quickly.

## How to test 
Test on your favorite network! 
Example (you'll need to go into the file and change the network name)
`python3 stnlist_update_qaqc.py`

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [x] Documentation: 
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [x] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] I agree to delete the branch once it's merged to main 
