### PR TITLE
Set default chunks for datasets

### DIFF
--- a/test_platform/scripts/4_merge_data/MERGE_pipeline.py
+++ b/test_platform/scripts/4_merge_data/MERGE_pipeline.py
@@ -328,7 +328,6 @@ def write_zarr_to_s3(
 ) -> None:
     """
     Writes the xarray Dataset to a Zarr file and uploads to S3.
-    Writes with one chunk per variable.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary of changes & context
Set default chunks to one big chunk due to small size of data
Even for our large datasets, using a single chunk is still tiny. For some reason, `ds.to_zarr()` will split up into as many as 8 (!!) tiny chunks for our larger datasets. 

## How to test 
Test the `MERGE_run_for_single_station.py` script.


## Type of change
- [] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] None of the above  

## To-Do
- [x] Documentation: 
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [x] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] I agree to delete the branch once it's merged to main 
