### PR TITLE
Flag counts location update

### DIFF
--- a/test_platform/scripts/4_merge_data/merge_eraqc_counts.py
+++ b/test_platform/scripts/4_merge_data/merge_eraqc_counts.py
@@ -73,7 +73,7 @@ def eraqc_counts_native_timestep(
         flag_counts = flag_counts.astype(int)
 
         # send file to AWS
-        csv_s3_filepath = f"s3://wecc-historical-wx/4_merge_wx/{network}/eraqc_counts/{station}_flag_counts_native_timestep.csv"
+        csv_s3_filepath = f"s3://wecc-historical-wx/4_merge_wx/{network}/eraqc_counts_native_timestep/{station}_flag_counts_native_timestep.csv"
         flag_counts.to_csv(csv_s3_filepath, index=True)
 
         # Update logger
@@ -147,7 +147,7 @@ def eraqc_counts_hourly_timestep(
         flag_counts = flag_counts.astype(int)
 
         # send file to AWS
-        csv_s3_filepath = f"s3://wecc-historical-wx/4_merge_wx/{network}/eraqc_counts/{station}_flag_counts_hourly_standardized.csv"
+        csv_s3_filepath = f"s3://wecc-historical-wx/4_merge_wx/{network}/eraqc_counts_hourly_timestep/{station}_flag_counts_hourly_standardized.csv"
         flag_counts.to_csv(csv_s3_filepath, index=True)
 
         # Update logger


### PR DESCRIPTION
## Summary of changes & context
I just changed where the flag count CSVs are being stored, to make things easier down the line when I sum up counts for the success report.

## How to test 
Run the pipeline on a station of your choice and see that the CSVs are being stored in their own folders.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] None of the above  

## To-Do
- [ ] Documentation: 
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [ ] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] I agree to delete the branch once it's merged to main 
