### PR TITLE
Bug fix: Network start / end dates in stationlist incorrect

### DIFF
--- a/test_platform/scripts/4_merge_data/stnlist_update_merge.py
+++ b/test_platform/scripts/4_merge_data/stnlist_update_merge.py
@@ -1,7 +1,7 @@
 """
 stnlist_update_merge.py
 
-This script iterates through a specified network and checks to see what stations have been successfully been hourly standardized and merged,
+This script iterates through a specified network and checks to see what stations have been successfully hourly standardized and merged,
 updating the station list in the 1_raw_wx folder to reflect station availability. Error.csvs in the cleaned bucket are also parsed,
 with relevant errors added to the corresponding stations if station files do not pass merge, or if the errors occur during or after the merge process.
 


### PR DESCRIPTION
## Summary of changes & context
Added a new function into the `stationlist_merge_update.py` script that fixes the known issue with a few networks that were either (1) missing start / end dates (NDBC, MARITIME, CW3E) or (2) had incorrect end date of 2100-12-31 (SCAN, SNOTEL). 

## How to test 
Run `stationlist_merge_update.py` on any of the following networks: NDBC, MARITIME, CW3E, SCAN, SNOTEL. 

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] None of the above  

## To-Do
- [x] Documentation: 
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)
  - [x] Functions have [type hints](https://www.pythontutorial.net/python-basics/python-type-hints/)
- [x] Black formatting has been utilized
- [x] Tagged/notified at least 1 reviewer for this PR
- [x] All unnecessary files are removed from this PR (no station files or stationlist csvs!)
- [x] Any new files are placed in the appropriate location following the established organizational structure of the repository (see the README for more info)
- [x] I agree to delete the branch once it's merged to main 
