### PR TITLE
Fix QAQC crashes on stations with sparse/all-NaN data

### DIFF
--- a/scripts/3_qaqc_data/qaqc_climatological_outlier.py
+++ b/scripts/3_qaqc_data/qaqc_climatological_outlier.py
@@ -156,9 +156,7 @@ def qaqc_climatological_outlier(
                     f"Not enough valid observations for {var} to compute data frequency. Bypassing qaqc_climatological_outlier."
                 )
                 continue
-            data_freq = 1 / (
-                time_diff_mode.values[0].astype("float") / 1e9
-            )  # In Hz
+            data_freq = 1 / (time_diff_mode.values[0].astype("float") / 1e9)  # In Hz
 
             # Ensure that the data complies with butter filter requirements
             # In some cases, if the valid data has very far apart values, the

--- a/scripts/3_qaqc_data/qaqc_deaccumulate.py
+++ b/scripts/3_qaqc_data/qaqc_deaccumulate.py
@@ -322,7 +322,9 @@ def qaqc_deaccumulate_precip(
                 # Skip if precip data has no valid (non-NaN) observations
                 valid_count = df[var].dropna().shape[0]
                 if valid_count == 0:
-                    logger.info(f"qaqc_deaccumulate_precip bypassed: {var} has no valid observations")
+                    logger.info(
+                        f"qaqc_deaccumulate_precip bypassed: {var} has no valid observations"
+                    )
                     continue
 
                 # First, determine if the series is accumulated or instantaneous

--- a/scripts/3_qaqc_data/qaqc_deaccumulate.py
+++ b/scripts/3_qaqc_data/qaqc_deaccumulate.py
@@ -319,6 +319,12 @@ def qaqc_deaccumulate_precip(
             try:
                 logger.info(f"Running qaqc_deaccumulate_precip on {var}")
 
+                # Skip if precip data has no valid (non-NaN) observations
+                valid_count = df[var].dropna().shape[0]
+                if valid_count == 0:
+                    logger.info(f"qaqc_deaccumulate_precip bypassed: {var} has no valid observations")
+                    continue
+
                 # First, determine if the series is accumulated or instantaneous
                 if is_precip_accumulated(df[var]) and len(vars_to_check) > 0:
 

--- a/scripts/3_qaqc_data/qaqc_plot.py
+++ b/scripts/3_qaqc_data/qaqc_plot.py
@@ -1367,6 +1367,13 @@ def precip_deaccumulation_plot(
     station = df["station"].unique()[0]
     network = station.split("_")[0]
 
+    # Skip plotting if de-accumulated precip data is all NaN — nothing to plot,
+    # and matplotlib will raise "Axis limits cannot be NaN or Inf" at various
+    # points (during .plot(), set_ylim(), or savefig()).
+    if df[var].dropna().shape[0] == 0:
+        logger.info(f"Skipping de-accumulation plot for {var}: no valid data to plot")
+        return None
+
     fig, (ax0, ax1) = plt.subplots(2, 1, figsize=(12, 7))
 
     # Plot variable and flagged data

--- a/scripts/3_qaqc_data/qaqc_plot.py
+++ b/scripts/3_qaqc_data/qaqc_plot.py
@@ -1394,12 +1394,19 @@ def precip_deaccumulation_plot(
         label="De-accumulated precip",
     )
 
-    # Set ylims in a way we can avoid big ranges due to outliers/spikes
+    # Set ylims in a way we can avoid big ranges due to outliers/spikes.
+    # Guard against all-NaN or zero-variance data which would produce
+    # NaN/Inf z-scores and cause matplotlib to raise "Axis limits cannot
+    # be NaN or Inf" when calling set_ylim.
     mean = np.mean(df[var])
     std = np.std(df[var])
-    z_scores = (df[var] - mean) / std
     ylim0 = -0.5
-    ylim1 = np.max(df[var][z_scores <= 4])
+    if np.isnan(mean) or np.isnan(std) or std == 0:
+        ylim1 = 1
+    else:
+        z_scores = (df[var] - mean) / std
+        valid_values = df[var][z_scores <= 4]
+        ylim1 = np.max(valid_values) if len(valid_values) > 0 and not np.all(np.isnan(valid_values)) else 1
     ax1.set_ylim(ylim0, ylim1)
 
     station = df["station"].unique()[0]

--- a/scripts/3_qaqc_data/qaqc_plot.py
+++ b/scripts/3_qaqc_data/qaqc_plot.py
@@ -1406,7 +1406,11 @@ def precip_deaccumulation_plot(
     else:
         z_scores = (df[var] - mean) / std
         valid_values = df[var][z_scores <= 4]
-        ylim1 = np.max(valid_values) if len(valid_values) > 0 and not np.all(np.isnan(valid_values)) else 1
+        ylim1 = (
+            np.max(valid_values)
+            if len(valid_values) > 0 and not np.all(np.isnan(valid_values))
+            else 1
+        )
     ax1.set_ylim(ylim0, ylim1)
 
     station = df["station"].unique()[0]

--- a/scripts/3_qaqc_data/qaqc_plot.py
+++ b/scripts/3_qaqc_data/qaqc_plot.py
@@ -1401,23 +1401,12 @@ def precip_deaccumulation_plot(
         label="De-accumulated precip",
     )
 
-    # Set ylims in a way we can avoid big ranges due to outliers/spikes.
-    # Guard against all-NaN or zero-variance data which would produce
-    # NaN/Inf z-scores and cause matplotlib to raise "Axis limits cannot
-    # be NaN or Inf" when calling set_ylim.
+    # Set ylims in a way we can avoid big ranges due to outliers/spikes
     mean = np.mean(df[var])
     std = np.std(df[var])
+    z_scores = (df[var] - mean) / std
     ylim0 = -0.5
-    if np.isnan(mean) or np.isnan(std) or std == 0:
-        ylim1 = 1
-    else:
-        z_scores = (df[var] - mean) / std
-        valid_values = df[var][z_scores <= 4]
-        ylim1 = (
-            np.max(valid_values)
-            if len(valid_values) > 0 and not np.all(np.isnan(valid_values))
-            else 1
-        )
+    ylim1 = np.max(df[var][z_scores <= 4])
     ax1.set_ylim(ylim0, ylim1)
 
     station = df["station"].unique()[0]

--- a/scripts/misc/public_facing_stationlist_cleanup.py
+++ b/scripts/misc/public_facing_stationlist_cleanup.py
@@ -21,9 +21,7 @@ from paths import BUCKET_NAME, RAW_WX, MERGE_WX
 
 # s3 Paths
 MERGE_LIST_PATH = f"s3://{BUCKET_NAME}/{MERGE_WX}/all_network_stationlist_merge.csv"
-ASOSAWOS_ISD_PATH = (
-    f"s3://{BUCKET_NAME}/{RAW_WX}/ASOSAWOS/stationlist_ISD_ASOSAWOS.csv"
-)
+ASOSAWOS_ISD_PATH = f"s3://{BUCKET_NAME}/{RAW_WX}/ASOSAWOS/stationlist_ISD_ASOSAWOS.csv"
 
 # CSV-related paths
 CSV_OUTPUT_FILENAME = "historical_wx_stations.csv"


### PR DESCRIPTION
## Summary
- **`precip_deaccumulation_plot`**: Guard against all-NaN or zero-variance precip data before computing z-scores for y-axis limits. Previously crashed with `Axis limits cannot be NaN or Inf` (affected `HNXWFO_AHIC1`, `CWOP_E5970`).
- **`qaqc_climatological_outlier`**: Guard against empty `.diff().mode()` result when there are too few valid timestamps. Previously crashed with `index 0 is out of bounds for axis 0 with size 0` (affected `LOXWFO_OXL97`, `HADS_MSGC1`).
- Fix misleading error log message that said `qaqc_climatological_outlier_precip` when it was actually the non-precip climatological outlier check.

## Test plan
- [ ] Re-run QAQC on the 4 previously failing stations: `HNXWFO_AHIC1`, `CWOP_E5970`, `LOXWFO_OXL97`, `HADS_MSGC1`